### PR TITLE
fix(displayName): use Rocket.Chat display name for consultant in new-…

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacade.java
+++ b/src/main/java/de/caritas/cob/userservice/api/facade/EmailNotificationFacade.java
@@ -154,6 +154,7 @@ public class EmailNotificationFacade {
               .consultantAgencyService(consultantAgencyService)
               .consultingTypeManager(consultingTypeManager)
               .consultantService(consultantService)
+              .rocketChatService(messageClient)
               .applicationBaseUrl(applicationBaseUrl)
               .emailDummySuffix(identityClientConfig.getEmailDummySuffix())
               .tenantTemplateSupplier(tenantTemplateSupplier)

--- a/src/main/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplier.java
+++ b/src/main/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplier.java
@@ -12,6 +12,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import com.google.common.collect.Lists;
 import com.neovisionaries.i18n.LanguageCode;
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.helper.UsernameTranscoder;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 /** Supplier to provide mails to be sent when a new message has been written. */
 @Slf4j
@@ -50,6 +52,7 @@ public class NewMessageEmailSupplier implements EmailSupplier {
   private final ConsultantAgencyService consultantAgencyService;
   private final ConsultingTypeManager consultingTypeManager;
   private final ConsultantService consultantService;
+  private final RocketChatService rocketChatService;
   private final String applicationBaseUrl;
   private final String emailDummySuffix;
   private boolean multiTenancyEnabled;
@@ -213,28 +216,36 @@ public class NewMessageEmailSupplier implements EmailSupplier {
     }
 
     var usernameTranscoder = new UsernameTranscoder();
-    var consultantUsername = obtainConsultantUsername();
+    var consultantDisplayName = obtainConsultantDisplayName();
     var mailDTO =
         buildMailDtoForNewMessageNotificationAsker(
             asker.getEmail(),
             asker.getLanguageCode(),
-            usernameTranscoder.decodeUsername(consultantUsername),
+            usernameTranscoder.decodeUsername(consultantDisplayName),
             usernameTranscoder.decodeUsername(asker.getUsername()));
 
     return singletonList(mailDTO);
   }
 
-  private String obtainConsultantUsername() {
+  private String obtainConsultantDisplayName() {
+    var consultant = resolveConsultant();
+    return rocketChatService
+        .findUserAndAddToCache(consultant.getRocketChatId())
+        .map(userMap -> (String) userMap.get("displayName"))
+        .filter(StringUtils::isNotBlank)
+        .orElseGet(consultant::getUsername);
+  }
+
+  private Consultant resolveConsultant() {
     if (isSessionBelongsToConsultant()) {
-      return session.getConsultant().getUsername();
+      return session.getConsultant();
     } else {
       return consultantService
           .getConsultant(userId)
           .orElseThrow(
               () ->
                   new InternalServerErrorException(
-                      String.format("Consultant with id %s not found.", userId)))
-          .getUsername();
+                      String.format("Consultant with id %s not found.", userId)));
     }
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplierTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/service/emailsupplier/NewMessageEmailSupplierTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.reflect.Whitebox.setInternalState;
 
+import de.caritas.cob.userservice.api.adapters.rocketchat.RocketChatService;
 import de.caritas.cob.userservice.api.config.auth.UserRole;
 import de.caritas.cob.userservice.api.exception.httpresponses.InternalServerErrorException;
 import de.caritas.cob.userservice.api.manager.consultingtype.ConsultingTypeManager;
@@ -40,6 +41,7 @@ import de.caritas.cob.userservice.mailservice.generated.web.model.MailDTO;
 import de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
@@ -67,6 +69,8 @@ public class NewMessageEmailSupplierTest {
 
   @Mock private ConsultantService consultantService;
 
+  @Mock private RocketChatService rocketChatService;
+
   @Mock private Logger logger;
 
   @Mock private TenantTemplateSupplier tenantTemplateSupplier;
@@ -84,6 +88,7 @@ public class NewMessageEmailSupplierTest {
             .consultantAgencyService(consultantAgencyService)
             .consultingTypeManager(consultingTypeManager)
             .consultantService(consultantService)
+            .rocketChatService(rocketChatService)
             .applicationBaseUrl("app baseurl")
             .emailDummySuffix("dummySuffix")
             .releaseToggleService(releaseToggleService)
@@ -280,6 +285,70 @@ public class NewMessageEmailSupplierTest {
     assertThat(templateData.get(1).getValue(), is("username"));
     assertThat(templateData.get(2).getKey(), is("url"));
     assertThat(templateData.get(2).getValue(), is("app baseurl"));
+  }
+
+  @Test
+  public void
+      generateEmails_Should_UseRocketChatDisplayName_When_ConsultantHasDisplayNameInRocketChat() {
+    when(roles.contains(UserRole.CONSULTANT.getValue())).thenReturn(true);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getRocketChatId()).thenReturn("rcUserId");
+    when(session.getConsultant()).thenReturn(consultant);
+    when(consultant.getId()).thenReturn(USER.getUserId());
+    when(session.getUser()).thenReturn(USER);
+    when(rocketChatService.findUserAndAddToCache("rcUserId"))
+        .thenReturn(Optional.of(Map.of("displayName", "MaditaU25HH")));
+
+    List<MailDTO> generatedMails = this.newMessageEmailSupplier.generateEmails();
+
+    assertThat(generatedMails, hasSize(1));
+    MailDTO generatedMail = generatedMails.get(0);
+    List<TemplateDataDTO> templateData = generatedMail.getTemplateData();
+    assertThat(templateData.get(0).getKey(), is("consultantName"));
+    assertThat(templateData.get(0).getValue(), is("MaditaU25HH"));
+  }
+
+  @Test
+  public void
+      generateEmails_Should_FallBackToUsername_When_ConsultantHasNoDisplayNameInRocketChat() {
+    when(roles.contains(UserRole.CONSULTANT.getValue())).thenReturn(true);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getUsername()).thenReturn(USERNAME_ENCODED);
+    when(consultant.getRocketChatId()).thenReturn("rcUserId");
+    when(session.getConsultant()).thenReturn(consultant);
+    when(consultant.getId()).thenReturn(USER.getUserId());
+    when(session.getUser()).thenReturn(USER);
+    // Rocket.Chat user found, but without a "name" set -> mapper doesn't add "displayName" key
+    when(rocketChatService.findUserAndAddToCache("rcUserId"))
+        .thenReturn(Optional.of(Map.of("id", "rcUserId")));
+
+    List<MailDTO> generatedMails = this.newMessageEmailSupplier.generateEmails();
+
+    assertThat(generatedMails, hasSize(1));
+    MailDTO generatedMail = generatedMails.get(0);
+    List<TemplateDataDTO> templateData = generatedMail.getTemplateData();
+    assertThat(templateData.get(0).getKey(), is("consultantName"));
+    assertThat(templateData.get(0).getValue(), is("Username!#123"));
+  }
+
+  @Test
+  public void generateEmails_Should_FallBackToUsername_When_RocketChatUserCannotBeFound() {
+    when(roles.contains(UserRole.CONSULTANT.getValue())).thenReturn(true);
+    Consultant consultant = mock(Consultant.class);
+    when(consultant.getUsername()).thenReturn(USERNAME_ENCODED);
+    when(consultant.getRocketChatId()).thenReturn("rcUserId");
+    when(session.getConsultant()).thenReturn(consultant);
+    when(consultant.getId()).thenReturn(USER.getUserId());
+    when(session.getUser()).thenReturn(USER);
+    when(rocketChatService.findUserAndAddToCache("rcUserId")).thenReturn(Optional.empty());
+
+    List<MailDTO> generatedMails = this.newMessageEmailSupplier.generateEmails();
+
+    assertThat(generatedMails, hasSize(1));
+    MailDTO generatedMail = generatedMails.get(0);
+    List<TemplateDataDTO> templateData = generatedMail.getTemplateData();
+    assertThat(templateData.get(0).getKey(), is("consultantName"));
+    assertThat(templateData.get(0).getValue(), is("Username!#123"));
   }
 
   @Test


### PR DESCRIPTION
…message asker email

The email notifying an advice seeker about a new consultant message showed the consultant's database username (obtainConsultantUsername) instead of their Rocket.Chat display name. Both can diverge because the display name is editable via the consultant's profile and lives only in Rocket.Chat, while the username is fixed at account creation.

Resolve the display name via RocketChatService.findUserAndAddToCache and fall back to the username if none is set in Rocket.Chat.

Refs: CARITAS-1001
